### PR TITLE
Two fixes to CBRequest authorizedRequest

### DIFF
--- a/Classes/CBRequest.m
+++ b/Classes/CBRequest.m
@@ -30,8 +30,9 @@
                 handler(JSON, nil);
             });
             
-        } failure:nil];
-        
+        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+            handler(nil, error);
+        }];
     } else {
         handler(nil, nil); // already authorized
     }


### PR DESCRIPTION
Change a9e1043 fixes authorizedRequest to call the handler on failure.

Change 49e8836 updates authorizedRequest to handle multiple calls when the tokens need refreshing.
